### PR TITLE
Switched to recommended version of kafka_2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
          <groupId>org.apache.kafka</groupId>
          <artifactId>kafka_2.11</artifactId>
-         <version>0.10.1.0</version>
+         <version>2.4.1</version>
       </dependency>
       <dependency>
          <groupId>org.json</groupId>


### PR DESCRIPTION
# Purpose
This PR contains a small change to the kafka_2.11 dependency in the pom.xml. There are apparently some vulnerabilities associated with kafka_2.11 version 0.10.1.0, so we should use version 2.4.1.

## Note
Functionality still needs to be verified, but I don't expect to encounter any issues.