### PR TITLE
Renamed mocked variables in DepositControllerTest.java

### DIFF
--- a/src/test/java/jpo/sdw/depositor/controller/DepositControllerTest.java
+++ b/src/test/java/jpo/sdw/depositor/controller/DepositControllerTest.java
@@ -26,13 +26,13 @@ public class DepositControllerTest {
    JavaMailSender sender;
 
    @Mocked
-   KafkaConsumerFactory capturingKafkaConsumerFactory;
+   KafkaConsumerFactory mockedCapturingKafkaConsumerFactory;
 
    @Mocked
-   KafkaConsumerRestDepositor capturingKafkaConsumerRestDepositor;
+   KafkaConsumerRestDepositor mockedCapturingKafkaConsumerRestDepositor;
    
    @Mocked
-   URI capturingURI;
+   URI mockedCapturingURI;
 
    @Test
    public void shouldRun() throws URISyntaxException {
@@ -41,7 +41,7 @@ public class DepositControllerTest {
          {
             injectableDepositorProperties.getDestinationUrl(); result = "127.0.0.1";
 
-            capturingKafkaConsumerRestDepositor.run((String[]) any);
+            mockedCapturingKafkaConsumerRestDepositor.run((String[]) any);
             times = 1;
          }
       };


### PR DESCRIPTION
## Changes
Several variables in the DepositControllerTest class have been renamed to indicate that they are mocked.

## Testing
Unit tests have been verified to pass with these changes.

## PR Comment
This addresses the following USDOT PR comment:
https://github.com/usdot-jpo-ode/jpo-sdw-depositor/pull/23#discussion_r1371947603