### PR TITLE
Empty Destination URL String Check

### DIFF
--- a/src/main/java/jpo/sdw/depositor/DepositorProperties.java
+++ b/src/main/java/jpo/sdw/depositor/DepositorProperties.java
@@ -61,8 +61,9 @@ public class DepositorProperties implements EnvironmentAware {
       if (getEncodeType() == null)
          setEncodeType(DEFAULT_ENCODE_TYPE);
 
-      if (getDestinationUrl() == null)
+      if (getDestinationUrl() == null || getDestinationUrl().isEmpty()) {
          setDestinationUrl(DEFAULT_DESTINATION_URL);
+      }
 
       if (getSubscriptionTopics() == null || getSubscriptionTopics().length == 0) {
          String topics = String.join(",", DEFAULT_SUBSCRIPTION_TOPICS);


### PR DESCRIPTION
## Changes
A check for whether the destination URL is an empty string has been added. If it is empty, then the default URL will be used.

## Motivation
In the case where the SDW_DESTINATION_URL environment variable is commented out or not present in `.env`, the default was not being used. This resulted in an empty string being used for the destination URL.

## Testing
It has been verified that, with the new empty string check, the default URL gets used in the absence of the SDW_DESTINATION_URL environment variable.

## PR Comment
These changes address the following USDOT PR comment:
https://github.com/usdot-jpo-ode/jpo-sdw-depositor/pull/23#discussion_r1371920227