### PR TITLE
Changed version to 1.6.0-SNAPSHOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN mvn clean package -DskipTests
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /home
-COPY --from=builder /home/target/jpo-sdw-depositor-1.3.0.jar /home
+COPY --from=builder /home/target/jpo-sdw-depositor-1.6.0-SNAPSHOT.jar /home
 
 ENTRYPOINT ["java", \
 	"-jar", \
-	"/home/jpo-sdw-depositor-1.3.0.jar"]
+	"/home/jpo-sdw-depositor-1.6.0-SNAPSHOT.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
    </parent>
    <groupId>usdot.jpo.ode</groupId>
    <artifactId>jpo-sdw-depositor</artifactId>
-   <version>1.3.0</version>
+   <version>1.6.0-SNAPSHOT</version>
    <packaging>jar</packaging>
    <name>jpo-sdw-depositor</name>
 


### PR DESCRIPTION
## Problem
The version in the pom.xml file is outdated.

## Solution
The version has been updated to 1.4.0-SNAPSHOT in the pom.xml.

## Testing
The unit tests passed & the project compiles successfully using mvn locally.