### PR TITLE
Release notes for jpo-sdw-depositor 1.7.0

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,16 @@
 jpo-sdw-depositor Release Notes
 ----------------------------
 
+Version 1.7.0, released June 2024
+----------------------------------------
+### **Summary**
+The changes for the jpo-sdw-depositor 1.7.0 release include a Java update for the dev container, as well as revised documentation for accuracy and improved clarity/readability.
+
+Enhancements in this release
+- CDOT PR 19: Updated dev container to use Java 21
+- CDOT PR 20: Revised documentation for accuracy & improved clarity/readability
+
+
 Version 1.6.0, released February 2024
 ----------------------------------------
 


### PR DESCRIPTION
## Problem
Next month we will be releasing a new version of this project. Release notes need to be prepared.

## Solution
The `Release_notes.md` file has been updated for the 1.7.0 release.