### PR TITLE
Changed version to 1.7.0-SNAPSHOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN mvn clean package -DskipTests
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /home
-COPY --from=builder /home/target/jpo-sdw-depositor-1.6.0-SNAPSHOT.jar /home
+COPY --from=builder /home/target/jpo-sdw-depositor-1.7.0-SNAPSHOT.jar /home
 
 ENTRYPOINT ["java", \
 	"-jar", \
-	"/home/jpo-sdw-depositor-1.6.0-SNAPSHOT.jar"]
+	"/home/jpo-sdw-depositor-1.7.0-SNAPSHOT.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
    </parent>
    <groupId>usdot.jpo.ode</groupId>
    <artifactId>jpo-sdw-depositor</artifactId>
-   <version>1.6.0-SNAPSHOT</version>
+   <version>1.7.0-SNAPSHOT</version>
    <packaging>jar</packaging>
    <name>jpo-sdw-depositor</name>
 


### PR DESCRIPTION
## Problem
The version needs to be incremented for the release next month.

## Solution
The version of the project has been changed to 1.7.0-SNAPSHOT in anticipation for the 2024 Q2 Release.

## Testing
- Code compiles
- Unit tests pass
- Docker container verified to start as expected