### PR TITLE
Subscription topic override bug fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,9 @@
                   <loader.path>${loader.path}</loader.path>
                   <buildDirectory>${project.build.directory}</buildDirectory>
                </systemPropertyVariables>
+               <environmentVariables>
+                  <SDW_SUBSCRIPTION_TOPIC>testSubscriptionTopic</SDW_SUBSCRIPTION_TOPIC>
+                </environmentVariables>
             </configuration>
             <dependencies>
                <dependency>

--- a/src/main/java/jpo/sdw/depositor/DepositorProperties.java
+++ b/src/main/java/jpo/sdw/depositor/DepositorProperties.java
@@ -68,11 +68,12 @@ public class DepositorProperties implements EnvironmentAware {
       if (getSubscriptionTopics() == null || getSubscriptionTopics().length == 0) {
          // get environment variable SDW_SUBSCRIPTION_TOPIC
          String topics = System.getenv("SDW_SUBSCRIPTION_TOPIC");
-         subscriptionTopics = topics.split(",");
          if (topics == null || topics.isEmpty()) {
             topics = String.join(",", DEFAULT_SUBSCRIPTION_TOPICS);
             logger.info("No Kafka subscription topics specified in configuration, defaulting to {}", topics);
             subscriptionTopics = DEFAULT_SUBSCRIPTION_TOPICS;
+         } else {
+            subscriptionTopics = topics.split(",");
          }
       }
 

--- a/src/main/java/jpo/sdw/depositor/DepositorProperties.java
+++ b/src/main/java/jpo/sdw/depositor/DepositorProperties.java
@@ -2,8 +2,6 @@ package jpo.sdw.depositor;
 
 import java.util.regex.Pattern;
 
-import jakarta.annotation.PostConstruct;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +9,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
+
+import jakarta.annotation.PostConstruct;
 
 @ConfigurationProperties("sdw")
 @PropertySource("classpath:application.properties")
@@ -66,9 +66,14 @@ public class DepositorProperties implements EnvironmentAware {
       }
 
       if (getSubscriptionTopics() == null || getSubscriptionTopics().length == 0) {
-         String topics = String.join(",", DEFAULT_SUBSCRIPTION_TOPICS);
-         logger.info("No Kafka subscription topics specified in configuration, defaulting to {}", topics);
-         subscriptionTopics = DEFAULT_SUBSCRIPTION_TOPICS;
+         // get environment variable SDW_SUBSCRIPTION_TOPIC
+         String topics = System.getenv("SDW_SUBSCRIPTION_TOPIC");
+         subscriptionTopics = topics.split(",");
+         if (topics == null || topics.isEmpty()) {
+            topics = String.join(",", DEFAULT_SUBSCRIPTION_TOPICS);
+            logger.info("No Kafka subscription topics specified in configuration, defaulting to {}", topics);
+            subscriptionTopics = DEFAULT_SUBSCRIPTION_TOPICS;
+         }
       }
 
       if (getApiKey() == null || getApiKey().isEmpty()) {


### PR DESCRIPTION
This change updates the SDW-depositor to use the SDW_SUBSCRIPTION_TOPIC environment variable instead of the default value if present. These changes were tested locally using docker and all existing unit tests were verified to run correctly. 