### PR TITLE
Dockerfile jar rename

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,19 +3,15 @@
 {
 	"name": "Java",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"java.home": "/docker-java-home"
+	"customizations": {
+		"extensions": [
+			"vscjava.vscode-java-pack"
+		]
 	},
-	
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"vscjava.vscode-java-pack"
-	],
-
 
 	"containerEnv": {
 		"SHELL": "/bin/bash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build container
-FROM maven:3.8-eclipse-temurin-21-alpine as builder
-MAINTAINER 583114@bah.com
+FROM maven:3.8-eclipse-temurin-21-alpine AS builder
+LABEL maintainer="583114@bah.com"
 
 WORKDIR /home
 
@@ -14,8 +14,10 @@ RUN mvn clean package -DskipTests
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /home
-COPY --from=builder /home/target/jpo-sdw-depositor-1.8.0-SNAPSHOT.jar /home
+# Copy the jar file from the builder image to the new image 
+# since we run mvn clean package, there should only be one jar file in the target directory, and we can safely copy it with a wildcard
+COPY --from=builder /home/target/jpo-sdw-depositor-*-SNAPSHOT.jar /home/jpo-sdw-depositor.jar
 
 ENTRYPOINT ["java", \
 	"-jar", \
-	"/home/jpo-sdw-depositor-1.8.0-SNAPSHOT.jar"]
+	"/home/jpo-sdw-depositor.jar"]


### PR DESCRIPTION
## Problem

Each time the version is updated in the [pom.xml](https://github.com/CDOT-CV/jpo-sdw-depositor/blob/058cb39da5ccd346c4e88790cdc33b9a9dea7bb8/pom.xml#L16) the Dockerfile needs to be updated to reference the new version. This is tedious, error prone (as it takes human intervention), and can be automated.

## Solution

The Dockerfile is updated to copy the _versioned_ jar file produced by Spring Boot's `repackage` maven target (runs when `mvn package` is called on Line 11 in the dockerfile) to an _unversioned_  jar file on the docker image. This allows us to still produce versioned jar files when packaging and distributing, while letting us call the jar file by a static name in the resulting docker image.

## Testing

Locally I have run `docker compose up --build` and inspected the container and its logs to confirm that the jar file is copied over correctly and the application runs as expected. I have also used `./run.sh` to run locally (but I have no connection to Confluence Cloud, so I can't confirm it works past seeing that the application starts up and provides error logs about the CC connection).

## Notes/Additional Changes

-  (polish) The change in the Dockerfile from `MAINTAINER` to `LABEL` was suggested by the Docker plugin in VSCode, since `MAINTAINER` is a deprecated field superseded by `LABEL maintainer`. 
- (polish) The change in the Dockerfile `as` to `AS` is in response to a docker build warning that the casing was inconsistent
- (polish) The changes to `.devcontainer.json` were provided via the VSCode linter and editor. The `java.home` config value was unnecessary since we use the base[ openjdk](https://hub.docker.com/r/cimg/openjdk/) image which configures the home directory in a standard way that VSCode can automatically work with.