### PR TITLE
Fixed Dockerfile to correctly copy JAR after version update (SNAPSHOT removal)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM eclipse-temurin:21-jre-alpine
 WORKDIR /home
 # Copy the jar file from the builder image to the new image 
 # since we run mvn clean package, there should only be one jar file in the target directory, and we can safely copy it with a wildcard
-COPY --from=builder /home/target/jpo-sdw-depositor-*-SNAPSHOT.jar /home/jpo-sdw-depositor.jar
+COPY --from=builder /home/target/jpo-sdw-depositor-*.jar /home/jpo-sdw-depositor.jar
 
 ENTRYPOINT ["java", \
 	"-jar", \

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -14,6 +14,7 @@ linter recommendations. These changes enhance reliability and maintainability wh
 
 Enhancements in this release:
 - [CDOT PR 28](https://github.com/CDOT-CV/jpo-sdw-depositor/pull/28): Dockerfile jar rename
+- [CDOT PR 30](https://github.com/CDOT-CV/jpo-sdw-depositor/pull/30): Fixed Dockerfile to correctly copy JAR after version update (SNAPSHOT removal)
 
 Known issues:
 - No known issues at this time.


### PR DESCRIPTION
## Problem
The version was updated to exclude "SNAPSHOT," but the Dockerfile wasn't updated to reflect this change, causing the JAR file not to be copied correctly.

## Solution
The Dockerfile has been modified to remove "SNAPSHOT" from the COPY instruction that handles the JAR file, ensuring it is copied properly.

## Testing
The update has been tested locally using Docker Compose, and it has been confirmed that the JAR file is now being copied correctly.