### PR TITLE
Add release notes for 2025 Q3 release

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -10,6 +10,7 @@ Enhancements in this release:
 - [USDOT PR 54](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/pull/54): Add Workflow for External Issues Notification
 - [USDOT PR 55](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/pull/55): Migrate to Reusable Docker Workflows
 
+
 Version 1.9.1, released May 2025
 ----------------------------------------
 ### **Summary**

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,7 +1,7 @@
 jpo-sdw-depositor Release Notes
 ----------------------------
 
-Version 1.10.0, released October 2025
+Version 1.9.2, released October 2025
 ----------------------------------------
 ### **Summary**
 The changes for this release include adding a workflow for external issues notification and migrating to reusable Docker workflows. No changes were made to the functionality of the service.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,15 @@
 jpo-sdw-depositor Release Notes
 ----------------------------
 
+Version 1.10.0, released October 2025
+----------------------------------------
+### **Summary**
+The changes for this release include adding a workflow for external issues notification and migrating to reusable Docker workflows. No changes were made to the functionality of the service.
+
+Enhancements in this release:
+- [USDOT PR 54](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/pull/54): Add Workflow for External Issues Notification
+- [USDOT PR 55](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/pull/55): Migrate to Reusable Docker Workflows
+
 Version 1.9.1, released May 2025
 ----------------------------------------
 ### **Summary**

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
    </parent>
    <groupId>usdot.jpo.ode</groupId>
    <artifactId>jpo-sdw-depositor</artifactId>
-   <version>1.9.1</version>
+   <version>1.10.0</version>
    <packaging>jar</packaging>
    <name>jpo-sdw-depositor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
    </parent>
    <groupId>usdot.jpo.ode</groupId>
    <artifactId>jpo-sdw-depositor</artifactId>
-   <version>1.10.0</version>
+   <version>1.9.2</version>
    <packaging>jar</packaging>
    <name>jpo-sdw-depositor</name>
 


### PR DESCRIPTION
This PR adds release notes summarizing the recent updates to the jpo-sdw-depositor project from the past quarter and bumps the version to 1.10.0. While no changes from CDOT are present, there were some modifications to some workflows in the upstream USDOT repository.